### PR TITLE
add 'globals' js to every header

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -53,6 +53,8 @@
     <!-- JavaScripts -->
     <?php If (get_theme_option('Use Accessible Mega Menu')):
         queue_js_file(array('globals', 'vendor/jquery-accessibleMegaMenu'));
+    else:
+        queue_js_file(array('globals'));
     endif; ?>
     <?php // see footer for bootstrap-related js...
     echo head_js(); ?>


### PR DESCRIPTION
* closes #1
* adds the globals.js file to the header, which defines the missing Omeka object and allows the dropdown to be created